### PR TITLE
Use kind node image version v1.20.0 that is shipped with vulnerable containerd version 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Easiest way to show it working is to use [KinD](https://kind.sigs.k8s.io/docs/us
 
 Unless the node somehow has a lot of data in `/var/lib/kubelet/pki`, this should be a safe test.
 
-- `kind create cluster`
+- `kind create cluster --image=kindest/node:v1.20.0`
 - `kubectl create -f pod-manifest.yaml`
 - `kubectl exec poctest -- ls /var/lib/kubelet/pki/`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Easiest way to show it working is to use [KinD](https://kind.sigs.k8s.io/docs/us
 
 Unless the node somehow has a lot of data in `/var/lib/kubelet/pki`, this should be a safe test.
 
-- `kind create cluster --image=kindest/node:v1.20.0`
+- `kind create cluster --image=kindest/node:v1.21.1`
 - `kubectl create -f pod-manifest.yaml`
 - `kubectl exec poctest -- ls /var/lib/kubelet/pki/`
 


### PR DESCRIPTION
Use `kind` node image version `v1.20.0` that is shipped with vulnerable containerd version `1.4.0`. Currently containerd `1.5.10` is shipped with the latest version of kind image that I was mentioned in issue #3 